### PR TITLE
Improvements for 'allCampaigns' query

### DIFF
--- a/server/routes/graphql/resolvers/campaign.resolver.js
+++ b/server/routes/graphql/resolvers/campaign.resolver.js
@@ -34,17 +34,17 @@ export const allCampaigns = async (parent, {
 
   const total = await models.Campaign.count({});
 
-  const campaings = await models.Campaign.find({})
+  const campaigns = await models.Campaign.find({})
     .limit(limit)
     .skip(skip)
     .sort(sortObject)
     .populate('coupons')
     .populate('maker');
 
-  const campaingsWithDetails = addCouponsHuntedByMe(campaings, mycampaigns, numberOfHuntedCoupons)
+  const campaignsWithDetails = addCouponsHuntedByMe(campaigns, mycampaigns, numberOfHuntedCoupons)
 
   const returnObject = {
-    campaings: campaingsWithDetails,
+    campaigns: campaignsWithDetails,
     totalCount: total
   }
   return returnObject;
@@ -316,10 +316,10 @@ function getCampaignsWithHuntedCoupons(mycampaigns, hunterCoupons) {
   return data;
 }
 
-function addCouponsHuntedByMe(campaings, mycampaigns, numberOfHuntedCoupons) {
+function addCouponsHuntedByMe(campaigns, mycampaigns, numberOfHuntedCoupons) {
   let result = [];
-  for (let i = 0; i < campaings.length; i++) {
-    let campaign = campaings[i];
+  for (let i = 0; i < campaigns.length; i++) {
+    let campaign = campaigns[i];
     const isMyCampaign = findHuntedCampaign(campaign.id, mycampaigns);
     if (isMyCampaign) {
       campaign.couponsHuntedByMe =  numberOfHuntedCoupons[campaign.id];

--- a/server/routes/graphql/rootTypes.js
+++ b/server/routes/graphql/rootTypes.js
@@ -15,7 +15,7 @@ export default `
     # Get Campaign. Access: Maker
     campaign(id: String!): Campaign!
 
-    # Get all campaigns. Access: Maker
+    # Get all campaigns. Access: Hunter
     allCampaigns(limit: Int, skip: Int, sortField: String, sortDirection: Int): PaginatedCampaigns!
 
     # Get all campaigns by Maker. Access: Hunter

--- a/server/routes/graphql/types/Campaign.js
+++ b/server/routes/graphql/types/Campaign.js
@@ -25,6 +25,30 @@ export default `
     office: OfficeSimple
   }
 
+  type CampaignForHunter {
+    id: ID!
+    startAt: Timestamp!
+    endAt: Timestamp!
+    country: String
+    city: String
+    image: String
+    totalCoupons: Int!
+    huntedCoupons: Int!
+    redeemedCoupons: Int!
+    status: String!
+    title: String!
+    description: String
+    customMessage: String
+    deleted: Boolean
+    initialAgeRange: Int
+    finalAgeRange: Int
+    createdAt: Timestamp!
+    couponsHuntedByMe: Int!
+    coupons: [Coupon!]
+    maker: UserBase
+    office: OfficeSimple
+  }
+
   input AddCampaignInput {
     startAt: Timestamp!
     endAt: Timestamp!
@@ -62,7 +86,7 @@ export default `
   }
 
   type PaginatedCampaigns {
-    campaings: [Campaign!]
+    campaings: [CampaignForHunter!]
     totalCount: Int!
   }
 `;

--- a/server/routes/graphql/types/Campaign.js
+++ b/server/routes/graphql/types/Campaign.js
@@ -86,7 +86,7 @@ export default `
   }
 
   type PaginatedCampaigns {
-    campaings: [CampaignForHunter!]
+    campaigns: [CampaignForHunter!]
     totalCount: Int!
   }
 `;

--- a/test/api/campaign.spec.js
+++ b/test/api/campaign.spec.js
@@ -432,7 +432,7 @@ test('Campaign: Hunter: Should get all campaigns', async t => {
         {
           allCampaigns {
             totalCount
-            campaings{
+            campaigns{
               title
               couponsHuntedByMe
             }
@@ -454,12 +454,12 @@ test('Campaign: Hunter: Should get all campaigns', async t => {
   t.is(allCampaignsResponse.status, 200);
 
   const { body: { data: { allCampaigns } } } = allCampaignsResponse;
-  t.is(allCampaigns.campaings.length, 2);
+  t.is(allCampaigns.campaigns.length, 2);
   t.is(allCampaigns.totalCount, 2);
-  t.is(allCampaigns.campaings[0].title, 'Campaign 1');
-  t.is(allCampaigns.campaings[0].couponsHuntedByMe, 0);
-  t.is(allCampaigns.campaings[1].title, 'Campaign 2');
-  t.is(allCampaigns.campaings[1].couponsHuntedByMe, 1);
+  t.is(allCampaigns.campaigns[0].title, 'Campaign 1');
+  t.is(allCampaigns.campaigns[0].couponsHuntedByMe, 0);
+  t.is(allCampaigns.campaigns[1].title, 'Campaign 2');
+  t.is(allCampaigns.campaigns[1].couponsHuntedByMe, 1);
 });
 
 test('Campaign: Maker: Should get my campaigns', async t => {


### PR DESCRIPTION
Se agregaron algunas mejoras en la query 'allCampaigns' para saber si ya se ha capturado un cupon en alguna campaña. Ahora la query luce así:

```
{
  allCampaigns{
    totalCount
    campaigns{
      id
      title
      status
      couponsHuntedByMe
    }
  }
}
```