### PR TITLE
Add age range instead of initial and final age

### DIFF
--- a/server/config/seed.js
+++ b/server/config/seed.js
@@ -89,7 +89,8 @@ const seedDatabase = async () => {
     office: office._id,
     startAt: Date.now(),
     endAt: new Date().setMonth(new Date().getMonth() + 3),
-    totalCoupons: 100
+    totalCoupons: 100,
+    rangeAge: [1,3,4]
   });
 
   await Office.findByIdAndUpdate(office._id,

--- a/server/models/campaign.model.js
+++ b/server/models/campaign.model.js
@@ -39,20 +39,6 @@ var CampaignSchema = new Schema({
     type: Number,
     default: 0
   },
-  initialAgeRange: {
-    type: Number,
-    default: 18,
-    min: [1, 'initialAgeRange should be in the range of 1 to 99.'],
-    max: [99, 'initialAgeRange should be in the range of 1 to 99.'],
-    required: true
-  },
-  finalAgeRange: {
-    type: Number,
-    default: 60,
-    min: [2, 'finalAgeRange should be in the range of 2 to 100.'],
-    max: [100, 'finalAgeRange should be in the range of 2 to 100.'],
-    required: true
-  },
   title: {
     type: String,
     required: true
@@ -79,7 +65,8 @@ var CampaignSchema = new Schema({
   coupons: [{
     type: Schema.ObjectId,
     ref: 'Coupon'
-  }]
+  }],
+  rangeAge: [Number]
 },
 {
   timestamps: true
@@ -108,13 +95,6 @@ CampaignSchema.virtual('status')
       return config.campaignStatus.EXPIRED;
     }
   });
-
-  CampaignSchema
-    .path('initialAgeRange')
-    .validate(function () {
-      return this.finalAgeRange > this.initialAgeRange;
-    },
-    'initialAgeRange should be less than finalAgeRange.');
 
   CampaignSchema
     .path('endAt')

--- a/server/routes/graphql/resolvers/campaign.resolver.js
+++ b/server/routes/graphql/resolvers/campaign.resolver.js
@@ -112,8 +112,6 @@ export const addCampaign = async (parent, args, context) => {
   const { couponsNumber } = input;
   const campaign = {
     totalCoupons: couponsNumber,
-    initialAgeRange: 18,
-    finalAgeRange: 60,
     maker: makerId,
     office: office._id,
     ...input

--- a/server/routes/graphql/types/Campaign.js
+++ b/server/routes/graphql/types/Campaign.js
@@ -18,12 +18,11 @@ export default `
     customMessage: String
     background: String
     deleted: Boolean
-    initialAgeRange: Int
-    finalAgeRange: Int
     createdAt: Timestamp!
     coupons: [Coupon!]
     maker: UserBase
     office: Office
+    rangeAge: [Int]
   }
 
   type CampaignForHunter {
@@ -42,8 +41,6 @@ export default `
     customMessage: String
     background: String
     deleted: Boolean
-    initialAgeRange: Int
-    finalAgeRange: Int
     createdAt: Timestamp!
     couponsHuntedByMe: Int!
     couponsRedeemedByMe: Int!
@@ -52,6 +49,7 @@ export default `
     maker: UserBase
     office: Office
     remainingCoupons: Int!
+    rangeAge: [Int]
   }
 
   type CampaignForMaker {
@@ -70,10 +68,9 @@ export default `
     customMessage: String
     background: String
     deleted: Boolean
-    initialAgeRange: Int
-    finalAgeRange: Int
     createdAt: Timestamp!
     remainingCoupons: Int!
+    rangeAge: [Int]
   }
 
   type PublicCampaigns {
@@ -91,11 +88,10 @@ export default `
     description: String
     customMessage: String
     deleted: Boolean
-    initialAgeRange: Int
-    finalAgeRange: Int
     remainingCoupons: Int!
     createdAt: Timestamp!
     office: PublicOffice
+    rangeAge: [Int]
   }
 
   input AddCampaignInput {
@@ -110,10 +106,9 @@ export default `
     background: String
     description: String
     customMessage: String
-    initialAgeRange: Int
-    finalAgeRange: Int
     officeId: String!
     upload: Upload
+    rangeAge: [Int]
   }
 
   input UpdateCampaignInput {
@@ -128,8 +123,7 @@ export default `
     background: String
     description: String
     customMessage: String
-    initialAgeRange: Int
-    finalAgeRange: Int
+    rangeAge: [Int]
   }
 
   input DeleteCampaignInput {

--- a/test/graphql/mutations/campaign.spec.js
+++ b/test/graphql/mutations/campaign.spec.js
@@ -72,8 +72,7 @@ test('Campaign: addCampaign > Should get access only maker role', async t => {
             startAt: 1521178272153
             endAt: 1522188672153
             couponsNumber: 20
-            initialAgeRange: 18
-            finalAgeRange: 50
+            rangeAge: [1,2,3]
             officeId: "${officeId}"
           }) {
             id
@@ -110,7 +109,7 @@ test('Campaign: addCampaign > Should get access only maker role', async t => {
 });
 
 test('Campaign: addCampaign > Should create a Campaign', async t => {
-  t.plan(15)
+  t.plan(14)
 
   function getAddCampaignQuery(officeId) {
     return {
@@ -125,8 +124,7 @@ test('Campaign: addCampaign > Should create a Campaign', async t => {
             startAt: 1521178272153
             endAt: 1522188672153
             couponsNumber: 20
-            initialAgeRange: 18
-            finalAgeRange: 50
+            rangeAge: [1,2,3]
             officeId: "${officeId}"
           }) {
             id
@@ -140,8 +138,7 @@ test('Campaign: addCampaign > Should create a Campaign', async t => {
             totalCoupons
             huntedCoupons
             redeemedCoupons
-            initialAgeRange
-            finalAgeRange
+            rangeAge
             createdAt
             deleted
           }
@@ -170,101 +167,9 @@ test('Campaign: addCampaign > Should create a Campaign', async t => {
   t.is(addCampaign.totalCoupons, 20);
   t.is(addCampaign.huntedCoupons, 0);
   t.is(addCampaign.redeemedCoupons, 0);
-  t.is(addCampaign.initialAgeRange, 18);
-  t.is(addCampaign.finalAgeRange, 50);
+  t.is(addCampaign.rangeAge.toString(), '1,2,3');
   t.truthy(addCampaign.createdAt);
   t.is(addCampaign.deleted, false);
-});
-
-test('Campaign: addCampaign > age range should be greater or equal to 1 and less than 100', async t => {
-  t.plan(9)
-
-  function getAddCampaignQuery(officeId, initialAgeRange, finalAgeRange) {
-    return {
-      query: `
-        mutation {
-          addCampaign(input: {
-            title: "Campaign 1"
-            country: "Ecuador"
-            city: "Loja"
-            description: "Description 1"
-            customMessage: "a custom message"
-            startAt: 1521178272153
-            endAt: 1522188672153
-            couponsNumber: 20
-            initialAgeRange: ${initialAgeRange}
-            finalAgeRange: ${finalAgeRange}
-            officeId: "${officeId}"
-          }) {
-            id
-            title
-          }
-        }
-      `
-    }
-  }
-
-  let serverRequest = request(app)
-  const { body: { data: { signIn: { token: tokenMaker } } } } = await utils.callToQraphql(serverRequest, makerLoginQuery);
-  const { body: { data: { addCompany } } } = await utils.callToQraphql(serverRequest, addCompanyQuery, tokenMaker);
-  const { body: { data: { addOffice } } } = await utils.callToQraphql(serverRequest, getAddOfficeQuery(addCompany.id), tokenMaker);
-
-  const { body: { errors: errorsTest1, data: dataTest1 } } = await utils.callToQraphql(serverRequest, getAddCampaignQuery(addOffice.id, -18, 50), tokenMaker);
-  t.falsy(dataTest1);
-  t.is(errorsTest1[0].message, 'Campaign validation failed: initialAgeRange: initialAgeRange should be in the range of 1 to 99.');
-  const { body: { errors: errorsTest2, data: dataTest2 } } = await utils.callToQraphql(serverRequest, getAddCampaignQuery(addOffice.id, 18, 101), tokenMaker);
-  t.falsy(dataTest2);
-  t.is(errorsTest2[0].message, 'Campaign validation failed: finalAgeRange: finalAgeRange should be in the range of 2 to 100.');
-  const { body: { errors: errorsTest3, data: dataTest3 } } = await utils.callToQraphql(serverRequest, getAddCampaignQuery(addOffice.id, 0, 50), tokenMaker);
-  t.falsy(dataTest3);
-  t.is(errorsTest3[0].message, 'Campaign validation failed: initialAgeRange: initialAgeRange should be in the range of 1 to 99.');
-  const { body: { data: { addCampaign: addCampaignTest4 } } } = await utils.callToQraphql(serverRequest, getAddCampaignQuery(addOffice.id, 1, 100), tokenMaker);
-  t.truthy(addCampaignTest4)
-  t.truthy(addCampaignTest4.id)
-  t.is(addCampaignTest4.title, 'Campaign 1')
-});
-
-test('Campaign: addCampaign > initialAgeRange should be less than finalAgeRange', async t => {
-  t.plan(5)
-
-  function getAddCampaignQuery(officeId, initialAgeRange, finalAgeRange) {
-    return {
-      query: `
-        mutation {
-          addCampaign(input: {
-            title: "Campaign 1"
-            country: "Ecuador"
-            city: "Loja"
-            description: "Description 1"
-            customMessage: "a custom message"
-            startAt: 1521178272153
-            endAt: 1522188672153
-            couponsNumber: 20
-            initialAgeRange: ${initialAgeRange}
-            finalAgeRange: ${finalAgeRange}
-            officeId: "${officeId}"
-          }) {
-            id
-            title
-          }
-        }
-      `
-    }
-  }
-
-  let serverRequest = request(app)
-  const { body: { data: { signIn: { token: tokenMaker } } } } = await utils.callToQraphql(serverRequest, makerLoginQuery);
-  const { body: { data: { addCompany } } } = await utils.callToQraphql(serverRequest, addCompanyQuery, tokenMaker);
-  const { body: { data: { addOffice } } } = await utils.callToQraphql(serverRequest, getAddOfficeQuery(addCompany.id), tokenMaker);
-
-  const { body: { errors: errorsTest1, data: dataTest1 } } = await utils.callToQraphql(serverRequest, getAddCampaignQuery(addOffice.id, 50, 25), tokenMaker);
-
-  t.falsy(dataTest1);
-  t.is(errorsTest1[0].message, 'Campaign validation failed: initialAgeRange: initialAgeRange should be less than finalAgeRange.');
-  const { body: { data: { addCampaign: addCampaignTest2 } } } = await utils.callToQraphql(serverRequest, getAddCampaignQuery(addOffice.id, 25, 50), tokenMaker);
-  t.truthy(addCampaignTest2)
-  t.truthy(addCampaignTest2.id)
-  t.is(addCampaignTest2.title, 'Campaign 1')
 });
 
 test('Campaign: addCampaign > endAt should be greater than startAt', async t => {
@@ -281,8 +186,7 @@ test('Campaign: addCampaign > endAt should be greater than startAt', async t => 
             startAt: 1522188672153
             endAt: 1521178272153
             couponsNumber: 20
-            initialAgeRange: 18
-            finalAgeRange: 50
+            rangeAge: [1,2,3]
             officeId: "${officeId}"
           }) {
             id
@@ -319,8 +223,7 @@ test('Campaign: updateCampaign > Should update a Campaign', async t => {
             startAt: 1521178272153
             endAt: 1522188672153
             couponsNumber: 20
-            initialAgeRange: 18
-            finalAgeRange: 50
+            rangeAge: [1,2,3]
             officeId: "${officeId}"
           }) {
             id
@@ -382,8 +285,7 @@ test('Campaign: deleteCampaign > Should delete a Campaign', async t => {
             startAt: 1521178272153
             endAt: 1522188672153
             couponsNumber: 20
-            initialAgeRange: 18
-            finalAgeRange: 50
+            rangeAge: [1,2,3]
             officeId: "${officeId}"
           }) {
             id
@@ -436,8 +338,7 @@ test('Campaign: captureCoupon > Should create a coupon after the hunter capture 
             startAt: ${Date.now()}
             endAt: ${Date.now() + 7200000}
             couponsNumber: 10
-            initialAgeRange: 18
-            finalAgeRange: 50
+            rangeAge: [1,2,3]
             officeId: "${officeId}"
           }) {
             id
@@ -509,8 +410,7 @@ test('Campaign: deleteCampaign > Should validate if there are hunted coupons and
             startAt: ${Date.now()}
             endAt: ${Date.now() + 7200000}
             couponsNumber: 20
-            initialAgeRange: 18
-            finalAgeRange: 50
+            rangeAge: [1,2,3]
             officeId: "${officeId}"
           }) {
             id
@@ -587,8 +487,7 @@ test('Campaign: addCampaign > Should add background when the Campaign is created
             endAt: 1522188672153
             couponsNumber: 20
             background: "${background}"
-            initialAgeRange: 18
-            finalAgeRange: 50
+            rangeAge: [1,2,3]
             officeId: "${officeId}"
           }) {
             id
@@ -603,8 +502,7 @@ test('Campaign: addCampaign > Should add background when the Campaign is created
             huntedCoupons
             background
             redeemedCoupons
-            initialAgeRange
-            finalAgeRange
+            rangeAge
             createdAt
             deleted
           }

--- a/test/graphql/mutations/coupon.spec.js
+++ b/test/graphql/mutations/coupon.spec.js
@@ -68,8 +68,7 @@ function getAddCampaignQuery(officeId) {
           startAt: ${Date.now()}
           endAt: ${Date.now() + 7200000}
           couponsNumber: 15
-          initialAgeRange: 18
-          finalAgeRange: 50
+          rangeAge: [1,2,3]
           officeId: "${officeId}"
         }) {
           id
@@ -584,8 +583,7 @@ test('Campaign: captureCoupon > Should return an error if the Campaing is SOLD-O
             startAt: ${Date.now()}
             endAt: ${Date.now() + 7200000}
             couponsNumber: 2
-            initialAgeRange: 18
-            finalAgeRange: 50
+            rangeAge: [1,3,4]
             officeId: "${officeId}"
           }) {
             id

--- a/test/graphql/queries/campaign.spec.js
+++ b/test/graphql/queries/campaign.spec.js
@@ -74,8 +74,7 @@ test('Campaign: campaign > Should get a Campaign', async t => {
             startAt: 1521178272153
             endAt: 1522188672153
             couponsNumber: 20
-            initialAgeRange: 18
-            finalAgeRange: 50
+            rangeAge: [1,2]
             officeId: "${officeId}"
           }) {
             id
@@ -133,8 +132,7 @@ test('Campaign: Hunter: allCampaigns > Should get all campaigns', async t => {
             startAt: ${Date.now()}
             endAt: ${Date.now() + 7200000}
             couponsNumber: 20
-            initialAgeRange: 18
-            finalAgeRange: 50
+            rangeAge: [1,2]
             officeId: "${officeId}"
           }) {
             id
@@ -233,8 +231,7 @@ test('Campaign: Hunter: allCampaigns > Should get all campaigns with the flag ca
             startAt: ${Date.now()}
             endAt: ${Date.now() + 7200000}
             couponsNumber: 20
-            initialAgeRange: 18
-            finalAgeRange: 50
+            rangeAge: [1,2]
             officeId: "${officeId}"
           }) {
             id
@@ -328,8 +325,7 @@ test('Campaign: Hunter: allCampaigns > Return empty array if there is not coupon
             startAt: 1521178272153
             endAt: 1522188672153
             couponsNumber: 20
-            initialAgeRange: 18
-            finalAgeRange: 50
+            rangeAge: [1,2]
             officeId: "${officeId}"
           }) {
             id
@@ -390,8 +386,7 @@ test('Campaign: Maker: myCampaigns > Should get my campaigns', async t => {
             startAt: 1521178272153
             endAt: 1522188672153
             couponsNumber: 20
-            initialAgeRange: 18
-            finalAgeRange: 50
+            rangeAge: [1,2]
             officeId: "${officeId}"
           }) {
             id
@@ -448,8 +443,7 @@ test('Campaign: huntedCouponsByCampaign > Should get an empty array if there are
             startAt: ${Date.now()}
             endAt: ${Date.now() + 7200000}
             couponsNumber: 10
-            initialAgeRange: 18
-            finalAgeRange: 50
+            rangeAge: [1,2]
             officeId: "${officeId}"
           }) {
             id
@@ -516,8 +510,7 @@ test('Campaign: huntersByCampaign > should get the hunter list of a specific cam
             startAt: ${Date.now()}
             endAt: ${Date.now() + 7200000}
             couponsNumber: ${couponsNumber}
-            initialAgeRange: 18
-            finalAgeRange: 50
+            rangeAge: [1,2]
             officeId: "${officeId}"
           }) {
             id
@@ -594,8 +587,7 @@ test('Campaign: huntersByCampaign > should get an empty array if there are no hu
             startAt: ${Date.now()}
             endAt: ${Date.now() + 7200000}
             couponsNumber: ${couponsNumber}
-            initialAgeRange: 18
-            finalAgeRange: 50
+            rangeAge: [1,2]
             officeId: "${officeId}"
           }) {
             id
@@ -631,8 +623,7 @@ test('Campaign: addCampaign > should have status: unavailable', async t => {
             startAt: ${Date.now() + 3600000 /* 1 hour */}
             endAt: ${Date.now() + 7200000 /* 2 hours */}
             couponsNumber: 10
-            initialAgeRange: 18
-            finalAgeRange: 50
+            rangeAge: [1,2]
             officeId: "${officeId}"
           }) {
             id
@@ -666,8 +657,7 @@ test('Campaign: campaign > should have status: available', async t => {
             startAt: ${Date.now()}
             endAt: ${Date.now() + 7200000 /* 2 hours */}
             couponsNumber: 10
-            initialAgeRange: 18
-            finalAgeRange: 50
+            rangeAge: [1,2]
             officeId: "${officeId}"
           }) {
             id
@@ -716,8 +706,7 @@ test('Campaign: campaign > should have status: expired', async t => {
             startAt: ${Date.now()}
             endAt: ${Date.now() + 1}
             couponsNumber: 10
-            initialAgeRange: 18
-            finalAgeRange: 50
+            rangeAge: [1,2]
             officeId: "${officeId}"
           }) {
             id
@@ -766,8 +755,7 @@ test('Campaign: campaign > should have status: soldout', async t => {
             startAt: ${Date.now()}
             endAt: ${Date.now() + 7200000}
             couponsNumber: 3
-            initialAgeRange: 18
-            finalAgeRange: 50
+            rangeAge: [1,2]
             officeId: "${officeId}"
           }) {
             id
@@ -840,8 +828,7 @@ test('Campaign: Hunter: allCampaigns > Should get all campaigns even if there ar
             startAt: ${Date.now()}
             endAt: ${Date.now() + 7200000}
             couponsNumber: 20
-            initialAgeRange: 18
-            finalAgeRange: 50
+            rangeAge: [1,2]
             officeId: "${officeId}"
           }) {
             id
@@ -899,8 +886,7 @@ test('Campaign: Public: publicCampaigns > Should get public campaigns', async t 
             startAt: ${Date.now()}
             endAt: ${Date.now() + 7200000}
             couponsNumber: 20
-            initialAgeRange: 18
-            finalAgeRange: 50
+            rangeAge: [1,2]
             officeId: "${officeId}"
           }) {
             id
@@ -931,8 +917,7 @@ test('Campaign: Public: publicCampaigns > Should get public campaigns', async t 
               description
               customMessage
               deleted
-              initialAgeRange
-              finalAgeRange
+              rangeAge
               remainingCoupons
               createdAt
               office {
@@ -998,8 +983,7 @@ test('Campaign: Hunter: campaignsByMakerId > Should return the campaigns by Make
             startAt: ${Date.now()}
             endAt: ${Date.now() + 7200000}
             couponsNumber: 20
-            initialAgeRange: 18
-            finalAgeRange: 50
+            rangeAge: [1,2]
             officeId: "${officeId}"
           }) {
             id
@@ -1025,8 +1009,7 @@ test('Campaign: Hunter: campaignsByMakerId > Should return the campaigns by Make
             huntedCoupons
             redeemedCoupons
             description
-            initialAgeRange
-            finalAgeRange
+            rangeAge
             couponsHuntedByMe
             couponsRedeemedByMe
             canHunt

--- a/test/graphql/queries/coupon.spec.js
+++ b/test/graphql/queries/coupon.spec.js
@@ -78,8 +78,7 @@ function getAddCampaignQuery(officeId) {
           startAt: ${Date.now()}
           endAt: ${Date.now() + 7200000}
           couponsNumber: 15
-          initialAgeRange: 18
-          finalAgeRange: 50
+          rangeAge: [1,2]
           officeId: "${officeId}"
         }) {
           id
@@ -173,8 +172,7 @@ test('User: Hunter: myRedeemedCoupons > Should return the list of my redeemed co
             startAt: ${Date.now()}
             endAt: ${Date.now() + 7200000}
             couponsNumber: 20
-            initialAgeRange: 18
-            finalAgeRange: 50
+            rangeAge: [1,2]
             officeId: "${officeId}"
           }) {
             id
@@ -278,8 +276,7 @@ test('Coupon: Maker: couponsByHunter > Should return coupons from a specific Hun
             startAt: ${Date.now()}
             endAt: ${Date.now() + 7200000}
             couponsNumber: 20
-            initialAgeRange: 18
-            finalAgeRange: 50
+            rangeAge: [1,2]
             officeId: "${officeId}"
           }) {
             id


### PR DESCRIPTION
Request:
```
{
  allCampaigns{
    campaigns{
      id
			title
      rangeAge
    }
    totalCount
  }
}
```
response
```
{
  "data": {
    "allCampaigns": {
      "campaigns": [
        {
          "id": "5b11a80881b62f07d7902570",
          "title": "10% de descuento en pg web",
          "rangeAge": [
            1,
            3,
            4
          ]
        }
      ],
      "totalCount": 1
    }
  }
}
```
⚠️ This will remove initialAgeRange and endAgeRange! 
This closes #131 