### PR TITLE
Emit subscription when the campaign is updated

### DIFF
--- a/server/config/shared.js
+++ b/server/config/shared.js
@@ -16,7 +16,8 @@ exports = module.exports = {
   subscriptionsTopics: {
     REDEEMED_COUPON_TOPIC: 'newRedeemedCoupon',
     EXPIRED_CAMPAIGN_TOPIC: 'newExpiredCampaign',
-    HUNTED_COUPON_TOPIC: 'newHuntedCoupon'
+    HUNTED_COUPON_TOPIC: 'newHuntedCoupon',
+    UPDATED_CAMPAIGN_TOPIC: 'updatedCampaign'
   },
   uploadsFolder: './uploads/',
   allowedImageFormat: ['.png', '.jpg', '.gif', '.jpeg', '.svg']

--- a/server/routes/graphql/resolvers.js
+++ b/server/routes/graphql/resolvers.js
@@ -94,6 +94,7 @@ export default {
   Subscription: {
     redeemedCoupon:  subscriptionResolver.redeemedCoupon(params),
     expiredCampaign: subscriptionResolver.expiredCampaign(params),
-    huntedCoupon: subscriptionResolver.huntedCoupon(params)
+    huntedCoupon: subscriptionResolver.huntedCoupon(params),
+    updatedCampaign: subscriptionResolver.updatedCampaign(params)
   }
 }

--- a/server/routes/graphql/resolvers/campaign.resolver.js
+++ b/server/routes/graphql/resolvers/campaign.resolver.js
@@ -1,9 +1,10 @@
 import fs from 'fs';
 import cloudinary from 'cloudinary';
 import config from '../../../config';
-import _ from 'lodash'
 import { storeFile, validateImage } from './file.resolver';
 import schedule from 'node-schedule'
+import * as CommonService from '../../../services/common.service'
+import * as NotificationService from '../../../services/notification.service'
 
 export const allCampaigns = async (parent, {
                                             limit = 10,
@@ -18,9 +19,9 @@ export const allCampaigns = async (parent, {
   sortObject[sortField] = sortDirection;
   const {_id: hunterId} = args.currentUser;
 
-  const myCoupons = await getHunterCoupons(models, hunterId);
-  const campaignsSelectedByMe = await getCampaignsSelectedByMe(models, myCoupons);
-  const campaignsWithCouponsSelected = mapCampaignsWithTotalOfCouponsHuntedByMe(campaignsSelectedByMe, myCoupons);
+  const myCoupons = await CommonService.getHunterCoupons(models, hunterId);
+  const campaignsSelectedByMe = await CommonService.getCampaignsSelectedByMe(models, myCoupons);
+  const campaignsWithCouponsSelected = CommonService.mapCampaignsWithTotalOfCouponsHuntedByMe(campaignsSelectedByMe, myCoupons);
   const total = await models.Campaign.count({});
   const getCampaigns = models.Campaign.find({});
   if(limit) getCampaigns.limit(limit);
@@ -31,7 +32,7 @@ export const allCampaigns = async (parent, {
     .populate('coupons')
     .populate('maker');
 
-  const campaignsWithDetails = addCouponsHuntedByMeToCampaigns(allSortedCampaigns, campaignsSelectedByMe, campaignsWithCouponsSelected)
+  const campaignsWithDetails = CommonService.addCouponsHuntedByMeToCampaigns(allSortedCampaigns, campaignsSelectedByMe, campaignsWithCouponsSelected)
   const returnObject = {
     campaigns: campaignsWithDetails,
     totalCount: total
@@ -151,7 +152,7 @@ export const addCampaign = async (parent, args, context) => {
       { new: true});
 
       if (makerId) {
-        notifyExpiredCampaignToMaker(pubsub, makerId, expiredCampaign);
+        NotificationService.notifyExpiredCampaignToMaker(pubsub, makerId, expiredCampaign);
       }
 
       task.cancel();
@@ -327,10 +328,10 @@ export const campaignsByMakerId = async(parent, args, { models }) => {
     throw new Error('Maker id not exist');
   }
 
-  const myCoupons = await getHunterCoupons(models, hunterId);
-  const campaignsSelectedByMe = await getCampaignsSelectedByMe(models, myCoupons);
-  const campaignsWithCouponsSelected = mapCampaignsWithTotalOfCouponsHuntedByMe(campaignsSelectedByMe, myCoupons);
-  const campaignsWithDetails = addCouponsHuntedByMeToCampaigns(makerCampaigns, campaignsSelectedByMe, campaignsWithCouponsSelected)
+  const myCoupons = await CommonService.getHunterCoupons(models, hunterId);
+  const campaignsSelectedByMe = await CommonService.getCampaignsSelectedByMe(models, myCoupons);
+  const campaignsWithCouponsSelected = CommonService.mapCampaignsWithTotalOfCouponsHuntedByMe(campaignsSelectedByMe, myCoupons);
+  const campaignsWithDetails = CommonService.addCouponsHuntedByMeToCampaigns(makerCampaigns, campaignsSelectedByMe, campaignsWithCouponsSelected)
 
   return campaignsWithDetails;
 }
@@ -395,49 +396,6 @@ function addCampaignsToMaker(makerId, campaignId, models){
   );
 }
 
-function findHuntedCampaign(campaignId, myCampaigns) {
-  return myCampaigns.find(mycampaign => {
-    return mycampaign.id === campaignId;
-  });
-}
-
-function mapCampaignsWithTotalOfCouponsHuntedByMe(campaignsSelectedByMe, myCoupons) {
-  let campaigns = {};
-  const myHuntedCoupons = _.filter(myCoupons, {status: config.couponStatus.HUNTED})
-  const myRedeemedCoupons = _.filter(myCoupons, {status: config.couponStatus.REDEEMED})
-  for(let i = 0; i < campaignsSelectedByMe.length; i++) {
-    const campaign = campaignsSelectedByMe[i];
-    const couponsHuntedInThisCampaign = _.intersectionBy(campaign.coupons, myHuntedCoupons, 'id');
-    const couponsRedeemedInThisCampaign = _.intersectionBy(campaign.coupons, myRedeemedCoupons, 'id');
-    campaigns[campaign.id] = {
-      couponsHunted: couponsRedeemedInThisCampaign.length + couponsHuntedInThisCampaign.length,
-      couponsRedeemed: couponsRedeemedInThisCampaign.length
-    }
-  }
-  return campaigns;
-}
-
-function addCouponsHuntedByMeToCampaigns(allSortedCampaigns, myCampaigns, campaignsWithCouponsSelected) {
-  let campaigns = [];
-  for (let i = 0; i < allSortedCampaigns.length; i++) {
-    let campaign = allSortedCampaigns[i];
-    const isMyCampaign = findHuntedCampaign(campaign.id, myCampaigns);
-    if (isMyCampaign) {
-      campaign.couponsHuntedByMe = campaignsWithCouponsSelected[campaign.id].couponsHunted;
-      campaign.couponsRedeemedByMe = campaignsWithCouponsSelected[campaign.id].couponsRedeemed;
-    } else {
-      campaign.couponsHuntedByMe = 0;
-      campaign.couponsRedeemedByMe = 0;
-    }
-    const couponsWereRedeemed = (campaign.couponsHuntedByMe === campaign.couponsRedeemedByMe);
-    const campaignIsAvailable = campaign.status === config.campaignStatus.AVAILABLE;
-    campaign.canHunt = (couponsWereRedeemed && campaignIsAvailable);
-
-    campaigns.push(campaign);
-  }
-  return campaigns;
-}
-
 function updateRelatedModels(params) {
   const {
     officeId,
@@ -448,32 +406,4 @@ function updateRelatedModels(params) {
   const promiseCampaignToOffice = addCampaignToOffice(officeId, campaignId, models)
   const promiseCampaignsToMaker = addCampaignsToMaker(makerId, campaignId, models)
   return Promise.all([promiseCampaignToOffice, promiseCampaignsToMaker])
-}
-
-
-const getHunterCoupons = async (models, hunterId) => {
-  const hunter = await models.Hunter
-                            .findOne({_id: hunterId})
-                            .populate('coupons') || {}
-
-  return hunter.coupons || [];
-}
-
-const getCampaignsSelectedByMe= async (models, myCoupons) => {
-  const campaigns = await models.Campaign
-                                .find({
-                                  coupons: {
-                                    '$in': myCoupons
-                                  }
-                                })
-                                .populate('coupons');
-
-  return campaigns
-
-}
-
-function notifyExpiredCampaignToMaker(pubsub, makerId, expiredCampaign) {
-  pubsub.publish(`${config.subscriptionsTopics.EXPIRED_CAMPAIGN_TOPIC}-${makerId}`, {
-    expiredCampaign
-  });
 }

--- a/server/routes/graphql/resolvers/subscription.resolver.js
+++ b/server/routes/graphql/resolvers/subscription.resolver.js
@@ -2,7 +2,7 @@ import config from '../../../config'
 
 export const redeemedCoupon = (params) => {
   return {
-    subscribe: (arg1, arg2, connectionParams) => {
+    subscribe: (arg1, variables, connectionParams) => {
       const hunterId = getUserId(connectionParams);
       if (hunterId) {
         return params.pubsub.asyncIterator(`${config.subscriptionsTopics.REDEEMED_COUPON_TOPIC}-${hunterId}`)
@@ -15,7 +15,7 @@ export const redeemedCoupon = (params) => {
 
 export const huntedCoupon = (params) => {
   return {
-    subscribe: (arg1, arg2, connectionParams) => {
+    subscribe: (arg1, variables, connectionParams) => {
       const makerId = getUserId(connectionParams);
       if (makerId) {
         return params.pubsub.asyncIterator(`${config.subscriptionsTopics.HUNTED_COUPON_TOPIC}-${makerId}`)
@@ -28,12 +28,26 @@ export const huntedCoupon = (params) => {
 
 export const expiredCampaign = (params) => {
   return {
-    subscribe: (arg1, arg2, connectionParams) => {
+    subscribe: (arg1, variables, connectionParams) => {
       const makerId = getUserId(connectionParams);
       if (makerId) {
         return params.pubsub.asyncIterator(`${config.subscriptionsTopics.EXPIRED_CAMPAIGN_TOPIC}-${makerId}`)
       } else {
         throw Error('There is a problem connecting to "expiredCampaign" subscription. Please check the connection params');
+      }
+    }
+  }
+};
+
+export const updatedCampaign = (params) => {
+  return {
+    subscribe: (arg1, variables, connectionParams) => {
+      const makerId = getUserId(connectionParams);
+      const campaignId = variables && variables.campaignId ? variables.campaignId : '';
+      if (makerId) {
+        return params.pubsub.asyncIterator(`${config.subscriptionsTopics.UPDATED_CAMPAIGN_TOPIC}-${campaignId}`)
+      } else {
+        throw Error('There is a problem connecting to "updatedCampaign" subscription. Please check the connection params');
       }
     }
   }

--- a/server/routes/graphql/rootTypes.js
+++ b/server/routes/graphql/rootTypes.js
@@ -124,5 +124,6 @@ export default `
     redeemedCoupon: CouponHunted!
     huntedCoupon: CouponHunted!
     expiredCampaign: Campaign!
+    updatedCampaign(campaignId: String!): CampaignForHunter!
   }
 `;

--- a/server/services/common.service.js
+++ b/server/services/common.service.js
@@ -1,8 +1,77 @@
 'use strict';
 
+import config from '../config';
+import _ from 'lodash'
+
 export function validationError(res, statusCode) {
   statusCode = statusCode || 422;
   return function(err) {
     return res.status(statusCode).json(err);
   };
 }
+
+
+export const getHunterCoupons = async (models, hunterId) => {
+  const hunter = await models.Hunter
+                            .findOne({_id: hunterId})
+                            .populate('coupons') || {}
+
+  return hunter.coupons || [];
+}
+
+export const getCampaignsSelectedByMe = async (models, myCoupons) => {
+  const campaigns = await models.Campaign
+    .find({
+      coupons: {
+        '$in': myCoupons
+      }
+    })
+    .populate('coupons');
+
+  return campaigns
+}
+
+export const mapCampaignsWithTotalOfCouponsHuntedByMe = (campaignsSelectedByMe, myCoupons) => {
+  let campaigns = {};
+  const myHuntedCoupons = _.filter(myCoupons, {status: config.couponStatus.HUNTED})
+  const myRedeemedCoupons = _.filter(myCoupons, {status: config.couponStatus.REDEEMED})
+  for(let i = 0; i < campaignsSelectedByMe.length; i++) {
+    const campaign = campaignsSelectedByMe[i];
+    const couponsHuntedInThisCampaign = _.intersectionBy(campaign.coupons, myHuntedCoupons, 'id');
+    const couponsRedeemedInThisCampaign = _.intersectionBy(campaign.coupons, myRedeemedCoupons, 'id');
+    campaigns[campaign.id] = {
+      couponsHunted: couponsRedeemedInThisCampaign.length + couponsHuntedInThisCampaign.length,
+      couponsRedeemed: couponsRedeemedInThisCampaign.length
+    }
+  }
+  return campaigns;
+}
+
+export const addCouponsHuntedByMeToCampaigns = (allSortedCampaigns, myCampaigns, campaignsWithCouponsSelected) => {
+  let campaigns = [];
+  for (let i = 0; i < allSortedCampaigns.length; i++) {
+    let campaign = allSortedCampaigns[i];
+    const isMyCampaign = findHuntedCampaign(campaign.id, myCampaigns);
+    if (isMyCampaign) {
+      campaign.couponsHuntedByMe = campaignsWithCouponsSelected[campaign.id].couponsHunted;
+      campaign.couponsRedeemedByMe = campaignsWithCouponsSelected[campaign.id].couponsRedeemed;
+    } else {
+      campaign.couponsHuntedByMe = 0;
+      campaign.couponsRedeemedByMe = 0;
+    }
+    const couponsWereRedeemed = (campaign.couponsHuntedByMe === campaign.couponsRedeemedByMe);
+    const campaignIsAvailable = campaign.status === config.campaignStatus.AVAILABLE;
+    campaign.canHunt = (couponsWereRedeemed && campaignIsAvailable);
+
+    campaigns.push(campaign);
+  }
+  return campaigns;
+}
+
+function findHuntedCampaign(campaignId, myCampaigns) {
+  return myCampaigns.find(mycampaign => {
+    return mycampaign.id === campaignId;
+  });
+}
+
+

--- a/server/services/notification.service.js
+++ b/server/services/notification.service.js
@@ -1,0 +1,36 @@
+import * as CommonService from './common.service'
+import config from '../config';
+
+export const notifyRedeemedCouponToHunter = (pubsub, hunterId, redeemedCoupon) => {
+  pubsub.publish(`${config.subscriptionsTopics.REDEEMED_COUPON_TOPIC}-${hunterId}`, {
+    redeemedCoupon
+  });
+}
+
+export const notifyHuntedCouponToMaker = (pubsub, makerId, huntedCoupon) => {
+  pubsub.publish(`${config.subscriptionsTopics.HUNTED_COUPON_TOPIC}-${makerId}`, {
+    huntedCoupon
+  });
+}
+
+export const notifyExpiredCampaignToMaker = (pubsub, makerId, expiredCampaign) => {
+  pubsub.publish(`${config.subscriptionsTopics.EXPIRED_CAMPAIGN_TOPIC}-${makerId}`, {
+    expiredCampaign
+  });
+}
+
+export const notifyUpdatedCampaing = async (pubsub, models, campaignId, hunterId) => {
+
+  const updatedCampaign = await models.Campaign.findOne({
+    _id: campaignId
+  });
+
+  const myCoupons = await CommonService.getHunterCoupons(models, hunterId);
+  const campaignsSelectedByMe = await CommonService.getCampaignsSelectedByMe(models, myCoupons);
+  const campaignsWithCouponsSelected = CommonService.mapCampaignsWithTotalOfCouponsHuntedByMe(campaignsSelectedByMe, myCoupons);
+  const campaignsWithDetails = CommonService.addCouponsHuntedByMeToCampaigns([updatedCampaign], campaignsSelectedByMe, campaignsWithCouponsSelected)
+
+  pubsub.publish(`${config.subscriptionsTopics.UPDATED_CAMPAIGN_TOPIC}-${campaignId}`, {
+    updatedCampaign: campaignsWithDetails[0]
+  });
+}


### PR DESCRIPTION
Resolves: https://github.com/Silverhill/coupon-backend/issues/128 

El evento se emite cada vez que una campaña sea capturada o cuando se reclama un cupoón

Campaña/cupon capturada:
![image](https://user-images.githubusercontent.com/3520164/40870830-c4dc2498-65f7-11e8-8bed-6f84bf3bcd75.png)

Cupón canjeado:
![image](https://user-images.githubusercontent.com/3520164/40870932-d679005e-65f7-11e8-9662-c4a6568f4808.png)

Ejemplo de la query:

```
subscription{
  updatedCampaign(campaignId:"5b1218b374c1ad057e6dee49"){
    id
    totalCoupons
    huntedCoupons
    redeemedCoupons
    remainingCoupons
    status
    canHunt
    couponsHuntedByMe
    couponsRedeemedByMe
    
  }
}
```

