### PR TITLE
query campaign no debería permitir consultar campañas de otras compañías

### DIFF
--- a/server/routes/graphql/resolvers/coupon.resolver.js
+++ b/server/routes/graphql/resolvers/coupon.resolver.js
@@ -135,8 +135,13 @@ export const getCouponsByHunter = async (parent, {
   sortObject[sortField] = sortDirection;
   const hunterId = args.hunterId;
   const { coupons } = await models.Hunter.findOne({ _id: hunterId }) || {};
+  const makerId = args.currentUser._id;
+  const campaigns = await models.Campaign.find({
+    maker: makerId
+  });
   const myCouponsInfo = await models.Coupon.find({
-    _id: { "$in": coupons || [] }
+    _id: { "$in": coupons || [] },
+    campaign: {"$in": campaigns || {}}
   })
     .limit(limit)
     .skip(skip)


### PR DESCRIPTION
this closes #129 