### PR TITLE
Add 'huntedAt' and 'redeemedAt' in the Coupon model

### DIFF
--- a/server/models/coupon.model.js
+++ b/server/models/coupon.model.js
@@ -20,6 +20,14 @@ var CouponSchema = new Schema({
   hunter: {
     type: Schema.ObjectId,
     ref: 'Hunter'
+  },
+  huntedAt: {
+    type: Date,
+    default: null
+  },
+  redeemedAt: {
+    type: Date,
+    default: null
   }
 },
 {

--- a/server/routes/graphql/resolvers/campaign.resolver.js
+++ b/server/routes/graphql/resolvers/campaign.resolver.js
@@ -332,7 +332,15 @@ export const campaignsByMakerId = async(parent, args, { models }) => {
                                   maker: makerId
                                 })
                                 .select('-coupons')
-                                .populate('maker') || [];
+                                .populate('maker')
+                                .populate({
+                                  path: 'office',
+                                  select: '-campaigns',
+                                  populate: {
+                                    path: 'company',
+                                    select: '-offices -maker'
+                                  }
+                                }) || [];
   } catch (error) {
     throw new Error('Maker id not exist');
   }

--- a/server/routes/graphql/resolvers/coupon.resolver.js
+++ b/server/routes/graphql/resolvers/coupon.resolver.js
@@ -49,6 +49,7 @@ export const captureCoupon = async (parent, args, { models, params }) => {
     const couponParams = {
       status: config.couponStatus.AVAILABLE,
       campaign: campaignId,
+      huntedAt: new Date(),
       hunter: hunterId
     }
 
@@ -236,7 +237,8 @@ function updateRedeemedCouponsCount(models, myCampaign) {
 function updateCouponToRedeemed(models, couponId) {
   return models.Coupon.findByIdAndUpdate(couponId,
     {
-      status: config.couponStatus.REDEEMED
+      status: config.couponStatus.REDEEMED,
+      redeemedAt: new Date()
     },
     { new: true }
   )

--- a/server/routes/graphql/resolvers/user.resolver.js
+++ b/server/routes/graphql/resolvers/user.resolver.js
@@ -112,10 +112,10 @@ export const myCoupons = async (parent, {
   const sortObject = {};
   sortObject[sortField] = sortDirection;
 
-  const {_id: id} = args.currentUser;
-  const { coupons } = await models.Hunter.findOne({ _id: id }) || {};
+  const {_id: hunterId } = args.currentUser;
+
   const myCouponsInfo = await models.Coupon.find({
-    _id: { "$in": coupons || [] },
+    hunter: hunterId,
     status: config.couponStatus.HUNTED,
   })
     .limit(limit)
@@ -128,7 +128,20 @@ export const myCoupons = async (parent, {
         path: 'maker',
         select: '-campaigns'
       }
-    }) || [];
+    })
+    .populate({
+      path: 'campaign',
+      select: '-coupons',
+      populate: {
+        path: 'office',
+        select: '-campaigns',
+        populate: {
+          path: 'company',
+          select: '-maker -offices'
+        }
+      }
+    })
+    .exec() || [];
 
   return myCouponsInfo;
 }
@@ -163,7 +176,11 @@ export const myRedeemedCoupons = async (parent, {
       select: '-coupons',
       populate: {
         path: 'office',
-        select: '-campaigns'
+        select: '-campaigns',
+        populate: {
+          path: 'company',
+          select: '-maker -offices'
+        }
       }
     })
     .exec() || [];

--- a/server/routes/graphql/types/Coupon.js
+++ b/server/routes/graphql/types/Coupon.js
@@ -16,6 +16,8 @@ export default `
     id: ID!
     code: String
     status: String
+    huntedAt: Timestamp
+    redeemedAt: Timestamp
     campaign: CampaignForHunter
   }
 

--- a/server/routes/graphql/types/Office.js
+++ b/server/routes/graphql/types/Office.js
@@ -24,6 +24,7 @@ export default `
     cellPhone: String
     address: String!
     email: String!
+    company: PublicCompany
   }
 
   type PublicOffice {

--- a/test/graphql/queries/coupon.spec.js
+++ b/test/graphql/queries/coupon.spec.js
@@ -348,3 +348,260 @@ test('Coupon: Maker: couponsByHunter > Should return coupons from a specific Hun
   t.is(couponsByHunter[1].campaign.title, 'Campaign 2');
 
 });
+
+test('Coupon: Hunter: myCoupons > Should return my coupons', async t => {
+  t.plan(9)
+
+  const myCouponsQuery = {
+    query: `
+      {
+        myCoupons {
+          ...on CouponHunted {
+            id
+            status
+            campaign {
+              title
+              maker {
+                id
+                name
+              }
+              office {
+                id
+                name
+              }
+            }
+          }
+        }
+      }
+    `
+  }
+
+  function getAddCampaignQuery(officeId, title) {
+    return {
+      query: `
+        mutation {
+          addCampaign(input: {
+            title: "${title}"
+            country: "Ecuador"
+            city: "Loja"
+            description: "Description 1"
+            startAt: ${Date.now()}
+            endAt: ${Date.now() + 7200000}
+            couponsNumber: 20
+            rangeAge: [1,2]
+            officeId: "${officeId}"
+          }) {
+            id
+            title
+          }
+        }
+      `
+    }
+  }
+
+  function getCaptureCouponQuery(id) {
+    return {
+      query: `
+        mutation {
+          captureCoupon(input: {
+            campaignId: "${id}"
+          }) {
+            id
+            code
+            status
+          }
+        }
+      `
+    }
+  }
+
+  let serverRequest = request(app)
+  const { body: { data: { signIn: { token: tokenMaker } } } } = await utils.callToQraphql(serverRequest, makerLoginQuery);
+  const { body: { data: { signIn: { token: tokenHunter } } } } = await utils.callToQraphql(serverRequest, hunterLoginQuery);
+  const { body: { data: { addCompany } } } = await utils.callToQraphql(serverRequest, addCompanyQuery, tokenMaker);
+  const { body: { data: { addOffice } } } = await utils.callToQraphql(serverRequest, getAddOfficeQuery(addCompany.id), tokenMaker);
+  const { body: { data: { addCampaign: campaign1 } } } = await utils.callToQraphql(serverRequest, getAddCampaignQuery(addOffice.id, 'Campaign 1'), tokenMaker);
+  const { body: { data: { addCampaign: campaign2 } } } = await utils.callToQraphql(serverRequest, getAddCampaignQuery(addOffice.id, 'Campaign 2'), tokenMaker);
+
+  await utils.callToQraphql(serverRequest, getCaptureCouponQuery(campaign1.id), tokenHunter);
+  await utils.callToQraphql(serverRequest, getCaptureCouponQuery(campaign2.id), tokenHunter);
+
+  //My coupons
+  const { body: { data: { myCoupons }}} = await utils.callToQraphql(serverRequest, myCouponsQuery, tokenHunter);
+
+  t.is(myCoupons.length, 2);
+  t.is(myCoupons[0].status, 'hunted');
+  t.is(myCoupons[0].campaign.title, 'Campaign 1');
+  t.is(myCoupons[0].campaign.maker.name, 'Maker');
+  t.is(myCoupons[0].campaign.office.name, 'Fogon Grill sucursal 1');
+  t.is(myCoupons[1].status, 'hunted');
+  t.is(myCoupons[1].campaign.title, 'Campaign 2');
+  t.is(myCoupons[1].campaign.maker.name, 'Maker');
+  t.is(myCoupons[1].campaign.office.name, 'Fogon Grill sucursal 1');
+});
+
+test('Coupon: Hunter: myCoupons > Should return my coupons with "huntedAt" and "redeemedAt" params', async t => {
+  t.plan(3)
+
+  const myCouponsQuery = {
+    query: `
+      {
+        myCoupons {
+          ...on CouponHunted {
+            id
+            status
+            huntedAt
+            redeemedAt
+          }
+        }
+      }
+    `
+  }
+
+  function getAddCampaignQuery(officeId, title) {
+    return {
+      query: `
+        mutation {
+          addCampaign(input: {
+            title: "${title}"
+            country: "Ecuador"
+            city: "Loja"
+            description: "Description 1"
+            startAt: ${Date.now()}
+            endAt: ${Date.now() + 7200000}
+            couponsNumber: 20
+            rangeAge: [1,2]
+            officeId: "${officeId}"
+          }) {
+            id
+            title
+          }
+        }
+      `
+    }
+  }
+
+  function getCaptureCouponQuery(id) {
+    return {
+      query: `
+        mutation {
+          captureCoupon(input: {
+            campaignId: "${id}"
+          }) {
+            id
+            code
+            status
+          }
+        }
+      `
+    }
+  }
+
+  let serverRequest = request(app)
+  const { body: { data: { signIn: { token: tokenMaker } } } } = await utils.callToQraphql(serverRequest, makerLoginQuery);
+  const { body: { data: { signIn: { token: tokenHunter } } } } = await utils.callToQraphql(serverRequest, hunterLoginQuery);
+  const { body: { data: { addCompany } } } = await utils.callToQraphql(serverRequest, addCompanyQuery, tokenMaker);
+  const { body: { data: { addOffice } } } = await utils.callToQraphql(serverRequest, getAddOfficeQuery(addCompany.id), tokenMaker);
+  const { body: { data: { addCampaign } } } = await utils.callToQraphql(serverRequest, getAddCampaignQuery(addOffice.id, 'Campaign 1'), tokenMaker);
+  //Hunt coupon
+  await utils.callToQraphql(serverRequest, getCaptureCouponQuery(addCampaign.id), tokenHunter);
+  //My coupons
+  const { body: { data: { myCoupons: myCoupons1 }}} = await utils.callToQraphql(serverRequest, myCouponsQuery, tokenHunter);
+
+  t.is(myCoupons1[0].status, 'hunted');
+  t.truthy(myCoupons1[0].huntedAt);
+  t.is(myCoupons1[0].redeemedAt, null);
+});
+
+test('Coupon: Hunter: myRedeemedCoupons > Should return my coupons with "huntedAt" and "redeemedAt" params', async t => {
+  t.plan(3)
+
+  const myRedeemedCouponsQuery = {
+    query: `
+      {
+        myRedeemedCoupons {
+          ...on CouponHunted {
+            id
+            status
+            huntedAt
+            redeemedAt
+          }
+        }
+      }
+    `
+  }
+
+  function getAddCampaignQuery(officeId, title) {
+    return {
+      query: `
+        mutation {
+          addCampaign(input: {
+            title: "${title}"
+            country: "Ecuador"
+            city: "Loja"
+            description: "Description 1"
+            startAt: ${Date.now()}
+            endAt: ${Date.now() + 7200000}
+            couponsNumber: 20
+            rangeAge: [1,2]
+            officeId: "${officeId}"
+          }) {
+            id
+            title
+          }
+        }
+      `
+    }
+  }
+
+  function getCaptureCouponQuery(id) {
+    return {
+      query: `
+        mutation {
+          captureCoupon(input: {
+            campaignId: "${id}"
+          }) {
+            id
+            code
+            status
+          }
+        }
+      `
+    }
+  }
+
+  function getRedeemCouponQuery(couponCode) {
+    return {
+      query: `
+        mutation {
+          redeemCoupon(input: {
+            couponCode: "${couponCode}"
+          }) {
+            id
+            code
+            status
+          }
+        }
+      `
+    }
+  }
+
+  let serverRequest = request(app)
+  const { body: { data: { signIn: { token: tokenMaker } } } } = await utils.callToQraphql(serverRequest, makerLoginQuery);
+  const { body: { data: { signIn: { token: tokenHunter } } } } = await utils.callToQraphql(serverRequest, hunterLoginQuery);
+  const { body: { data: { addCompany } } } = await utils.callToQraphql(serverRequest, addCompanyQuery, tokenMaker);
+  const { body: { data: { addOffice } } } = await utils.callToQraphql(serverRequest, getAddOfficeQuery(addCompany.id), tokenMaker);
+  const { body: { data: { addCampaign } } } = await utils.callToQraphql(serverRequest, getAddCampaignQuery(addOffice.id, 'Campaign 1'), tokenMaker);
+  //Hunt coupon
+  const { body: { data: { captureCoupon } } } = await utils.callToQraphql(serverRequest, getCaptureCouponQuery(addCampaign.id), tokenHunter);
+
+  //Redeem coupon
+  await utils.callToQraphql(serverRequest, getRedeemCouponQuery(captureCoupon.code), tokenMaker);
+
+  //My coupons
+  const { body: { data: { myRedeemedCoupons } }} = await utils.callToQraphql(serverRequest, myRedeemedCouponsQuery, tokenHunter);
+
+  t.is(myRedeemedCoupons[0].status, 'redeemed');
+  t.truthy(myRedeemedCoupons[0].huntedAt);
+  t.truthy(myRedeemedCoupons[0].redeemedAt);
+});


### PR DESCRIPTION
Issue: https://github.com/Silverhill/coupon-backend/issues/138

Adicionalmente, ciertas queries ahora retornan office y company:

**campaignsByMakerId**
```
{
  campaignsByMakerId(makerId:"5b05784ad1e8ad521ab3a9d9") {
    id
    office {
      id
      name
      company {
        businessName
      }
    }
  }
}
```
**myCoupons**
```
{
  myCoupons {
    ...on CouponHunted {
      id
      status
      huntedAt
      redeemedAt
      campaign {
        title
        office {
          name
          company {
            id
            businessName
          }
        }
      }
    }
  }
}
```
**myRedeemedCoupons**
```
{
  myRedeemedCoupons {
    ...on CouponHunted {
      id
      status
      huntedAt
      redeemedAt
      campaign {
        title
        office {
          name
          company {
            id
            businessName
          }
        }
      }
    }
  }
}
```